### PR TITLE
Je delete categories

### DIFF
--- a/rareapi/fixtures/categories.json
+++ b/rareapi/fixtures/categories.json
@@ -3,19 +3,26 @@
         "model": "rareapi.categories",
         "pk": 1,
         "fields": {
-            "label": "kitties n pups"
+            "label": "Uncategorized"
         }
     },
     {
         "model": "rareapi.categories",
         "pk": 2,
         "fields": {
-            "label": "large jungle creatures"
+            "label": "kitties n pups"
         }
     },
     {
         "model": "rareapi.categories",
         "pk": 3,
+        "fields": {
+            "label": "large jungle creatures"
+        }
+    },
+    {
+        "model": "rareapi.categories",
+        "pk": 4,
         "fields": {
             "label": "DAWGZ ONLY"
         }

--- a/rareapi/fixtures/posts.json
+++ b/rareapi/fixtures/posts.json
@@ -4,7 +4,7 @@
         "pk": 1,
         "fields": {
             "user": 1,
-            "category": 2,
+            "category": 3,
             "title": "BARKSGIVING APPROACHES",
             "publication_date": "2020-08-18",
             "image_url": "",
@@ -17,7 +17,7 @@
         "pk": 2,
         "fields": {
             "user": 1,
-            "category": 2,
+            "category": 3,
             "title": "Someting about dogs",
             "publication_date": "2020-09-28",
             "image_url": "",
@@ -30,7 +30,7 @@
         "pk": 3,
         "fields": {
             "user": 1,
-            "category": 2,
+            "category": 3,
             "title": "BARKSGIVING APPROACHES",
             "publication_date": "2020-10-30",
             "image_url": "",

--- a/rareapi/models/Posts.py
+++ b/rareapi/models/Posts.py
@@ -1,10 +1,18 @@
 """Database Post module"""
 from django.db import models
+from rareapi.models import Categories
+
+def get_uncategorized_category_instance():
+    """Get the Categories object from database that represents the "Uncategorized" category"""
+    return Categories.objects.get(label='Uncategorized')
 
 class Posts(models.Model):
     """Database Post model"""
     user = models.ForeignKey("RareUsers", on_delete=models.CASCADE)
-    category = models.ForeignKey("Categories", on_delete=models.CASCADE)
+    
+    # If associated category is deleted, set this Post's category to the "Uncategorized" category
+    category = models.ForeignKey("Categories", on_delete=models.SET(get_uncategorized_category_instance))
+
     title = models.CharField(max_length=300)
     publication_date = models.DateField()
     image_url = models.CharField(max_length=300)

--- a/rareapi/views/category.py
+++ b/rareapi/views/category.py
@@ -1,4 +1,5 @@
 """Category ViewSet and Serializers"""
+from rest_framework.status import HTTP_204_NO_CONTENT
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
 from rest_framework import status, serializers
@@ -44,6 +45,29 @@ class CategoryViewSet(ViewSet):
 
         serialized_categories = CategoriesSerializer(categories, many=True)
         return Response(serialized_categories.data, status=status.HTTP_200_OK)
+
+    def destroy(self, request, pk=None):
+        """DELETE a category with the given pk"""
+
+        try:
+            category = Categories.objects.get(pk=pk)
+
+        except Categories.DoesNotExist:
+            return Response(
+                {'message': 'There is no category with the specified ID.'},
+                status=status.HTTP_404_NOT_FOUND
+            )
+
+        if category.label == 'Uncategorized':
+            return Response(
+                {'message': 'Deleting the "Uncategorized" category is forbidden.'},
+                status=status.HTTP_403_FORBIDDEN
+            )
+
+        category.delete()
+        return Response({}, HTTP_204_NO_CONTENT)
+
+        
 
 class CategoriesSerializer(serializers.ModelSerializer):
     """JSON serializer for categories"""

--- a/rareapi/views/category.py
+++ b/rareapi/views/category.py
@@ -60,7 +60,7 @@ class CategoryViewSet(ViewSet):
 
         if category.label == 'Uncategorized':
             return Response(
-                {'message': 'Deleting the "Uncategorized" category is forbidden.'},
+                {'message': 'Deleting the `Uncategorized` category is forbidden.'},
                 status=status.HTTP_403_FORBIDDEN
             )
 


### PR DESCRIPTION
# Description
Implementing `DELETE` handler for categories. This process involves updating the fixtures for both Categories and Posts, because I created a new `Uncategorized` category. This category is set on a post if the Post had a foreign key to a once-existing category that was then deleted - as we discussed in our planning yesterday, we will not be doing a CASCADE delete on the Posts table in this situation, but instead are setting the Post's category to this now hard-coded "Uncategorized" category in the DB. I used the on_delete=SET strategy (https://jilles.me/django-foreignkeys-on_delete-handlers/#models-set-function-or-value-) in the Post model to accomplish this.

Fixes #173 (in client project board)

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Please describe step-by-step the process that a reviewer can follow to adequately test this PR. 
- [ ] First, crucially, run the new `categories.json` and `posts.json` fixtures by doing `python manage.py loaddata categories` followed by `python manage.py loaddata posts`. This will set up the "Uncategorized" category.
- [ ] In Postman, send a `DELETE` request to a category that exists in your database that is NOT the "Uncategorized" category (eg `DELETE http://localhost:8000/categories/2`). Verify that the category is deleted and the server responds with a 204 status code.
- [ ] In Postman, send a `DELETE` request to a category id that does not exist in your database. Verify that the server responds with a 404 status code and a descriptive message.
- [ ] In Postman, send a `DELETE` request to the category id of the "Uncategorized" category (should be ID=1). Verify that the server responds with a 403 (Forbidden) status code and a descriptive message.
- [ ] Send a GET request to your Posts. Check the category ids of the posts and, for a post in your database, send a `DELETE` request to categories and specify a category id that is currently attached to one of your posts. After this DELETE returns, GET Posts again and verify that any Post that had that category id now has their category id set to the "Uncategorized" category.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings