### PR TITLE
Fix Migration Error

### DIFF
--- a/rareapi/models/Posts.py
+++ b/rareapi/models/Posts.py
@@ -7,12 +7,9 @@ class Posts(models.Model):
     """Database Post model"""
     user = models.ForeignKey("RareUsers", on_delete=models.CASCADE)
 
-    def get_uncategorized_category_instance():
-        """Get the Categories object from database that represents the "Uncategorized" category"""
-        return Categories.objects.get(label='Uncategorized')
     
     # If associated category is deleted, set this Post's category to the "Uncategorized" category
-    category = models.ForeignKey("Categories", on_delete=models.SET(get_uncategorized_category_instance))
+    category = models.ForeignKey("Categories", on_delete=models.SET_DEFAULT, default=1)
 
     title = models.CharField(max_length=300)
     publication_date = models.DateField()

--- a/rareapi/models/Posts.py
+++ b/rareapi/models/Posts.py
@@ -2,13 +2,14 @@
 from django.db import models
 from rareapi.models import Categories
 
-def get_uncategorized_category_instance():
-    """Get the Categories object from database that represents the "Uncategorized" category"""
-    return Categories.objects.get(label='Uncategorized')
 
 class Posts(models.Model):
     """Database Post model"""
     user = models.ForeignKey("RareUsers", on_delete=models.CASCADE)
+
+    def get_uncategorized_category_instance():
+        """Get the Categories object from database that represents the "Uncategorized" category"""
+        return Categories.objects.get(label='Uncategorized')
     
     # If associated category is deleted, set this Post's category to the "Uncategorized" category
     category = models.ForeignKey("Categories", on_delete=models.SET(get_uncategorized_category_instance))
@@ -29,3 +30,5 @@ class Posts(models.Model):
         
         post_tags = self.posttags_set.all()
         return [ pt.tag for pt in post_tags]
+    
+    


### PR DESCRIPTION
# Description
Bug fix: When Migrating the models, this error was being thrown: AttributeError: type object 'Posts' has no attribute 'get_uncategorized_category_instance'

This was due to the get_uncategorized_category_instance function being defined outside the scope of the Posts class. 

This change uses the onDelete=set_Default property instead of the onDelete=Set property to avoid this error.
## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
# How Has This Been Tested?
Please describe step-by-step the process that a reviewer can follow to adequately test this PR. 
- [x] Before checking out this code, run 
`
rm -rf rareapi/migrations
rm db.sqlite3
python manage.py migrate
python manage.py makemigrations rareapi
python manage.py migrate rareapi`
Then verify that you see the attribute error
- [x] After checking out this branch, run the same commands. You should not see the error.
# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings