### PR TITLE
Je approve posts

### DIFF
--- a/rareapi/views/Posts.py
+++ b/rareapi/views/Posts.py
@@ -117,7 +117,35 @@ class PostViewSet(ViewSet):
                 new_posttag.save()
 
         return Response({}, status=status.HTTP_204_NO_CONTENT)
+
+    def partial_update(self, request, pk=None):
+        """Handle a partial update to a Post resource. Handles PATCH requests
+
+        Currently this will only update the `approved` property"""
+
+        try:
+            post = Posts.objects.get(pk=pk)
+        except Posts.DoesNotExist:
+            return Response(
+                {'message': 'There is no Post with the given id.'},
+                status=status.HTTP_404_NOT_FOUND)
+
+        if 'approved' in request.data:
+            # The user is trying to update the approved property on the post
+            if not request.auth.user.is_staff:
+                return Response(
+                    {'message': 'Only admin users can modify the approved status of a post'},
+                    status=status.HTTP_403_FORBIDDEN
+                )
+
+            post.approved = request.data['approved']
         
+        try:
+            post.save()
+        except ValidationError as ex:
+            return Response({"reason": ex.message}, status=status.HTTP_400_BAD_REQUEST)
+
+        return Response({}, status=status.HTTP_204_NO_CONTENT)       
 
     def list(self, request):
         """Handle GET requests to posts resource

--- a/rareapi/views/Posts.py
+++ b/rareapi/views/Posts.py
@@ -132,6 +132,7 @@ class PostViewSet(ViewSet):
 
         if 'approved' in request.data:
             # The user is trying to update the approved property on the post
+            # Only let them do it if they are an admin user
             if not request.auth.user.is_staff:
                 return Response(
                     {'message': 'Only admin users can modify the approved status of a post'},
@@ -140,6 +141,7 @@ class PostViewSet(ViewSet):
 
             post.approved = request.data['approved']
         
+        # Save whatever has been updated in the PATCH request
         try:
             post.save()
         except ValidationError as ex:


### PR DESCRIPTION
# Description
Adds server-side method to update the `approved` property of a Post. This is implemented via addition of a `partial_update` method to the Posts ViewSet, where `partial_update` corresponds to a `PATCH` request in Django ViewSet world.

Fixes #237 (on the client board)

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Please describe step-by-step the process that a reviewer can follow to adequately test this PR. 
- [ ] Run a GET request in Postman on post with id of 1, and check its `approved` status. (It will probably be true).
- [ ] Create a PATCH request in Postman, and set the body to ` { "approved": false }` and set the URL to `http://localhost:8000/posts/1`. Set the `Authorization` header to `Token 7f6d2aca4d0d1e7f4e606c36b592f7736000ee92`. This is the token of the admin user from the fixtures (so make sure to run fixtures if you don't have the admin user yet).
- [ ] Verify that that PATCH request flipped the `approved` status of that post to `false`.
- [ ] Change the `approved` value in the body of your PATCH request back to `true` and verify that it properly updates the Post object.
- [ ] Change the `Authorization` header of your PATCH request to `Token fa2eba9be8282d595c997ee5cd49f2ed31f65bed`. This is the token of the non-admin user from fixtures. Verify that if you try to PATCH and update the `approved` status, you get an HTTP 403 (Forbidden) response and the post is not updated.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings