### PR TITLE
Gs server profiles

### DIFF
--- a/news_hounds_django_server/urls.py
+++ b/news_hounds_django_server/urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls import include
 from django.urls import path
 from rest_framework import routers
-from rareapi.views import register_user, login_user, PostViewSet, TagViewSet, CategoryViewSet, CommentViewSet, PostTagsViewSet
+from rareapi.views import register_user, login_user, PostViewSet, TagViewSet, CategoryViewSet, CommentViewSet, PostTagsViewSet, ProfileViewSet
 
 
 """Router"""
@@ -11,6 +11,7 @@ router.register(r'tags', TagViewSet, 'tag')
 router.register(r'comments', CommentViewSet, 'comment')
 router.register(r'posttags', PostTagsViewSet, 'posttags' )
 router.register(r'categories', CategoryViewSet, 'category')
+router.register(r'profiles', ProfileViewSet, 'profile')
 
 urlpatterns = [
     path('', include(router.urls)),

--- a/rareapi/models/RareUsers.py
+++ b/rareapi/models/RareUsers.py
@@ -17,3 +17,7 @@ class RareUsers(models.Model):
     @property
     def username(self):
         return f"{self.user.username}"
+
+    @property
+    def is_staff(self):
+        return self.user.is_staff

--- a/rareapi/views/Profiles.py
+++ b/rareapi/views/Profiles.py
@@ -1,4 +1,3 @@
-from django.http.response import HttpResponseServerError
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 from rest_framework.decorators import action
@@ -20,7 +19,7 @@ class ProfileViewSet(ViewSet):
     def update_role(self, request, pk=None):
         try:
             rare_user = RareUsers.objects.get(pk=pk)
-            user = User.objects.get(pk=rare_user.id)
+            user = rare_user.user
         except RareUsers.DoesNotExist:
             return Response({'message': 'user does not exit'}, status=status.HTTP_404_NOT_FOUND)
         if not request.auth.user.is_staff:

--- a/rareapi/views/Profiles.py
+++ b/rareapi/views/Profiles.py
@@ -1,0 +1,16 @@
+from rest_framework.response import Response
+from rest_framework.viewsets import ViewSet
+from rest_framework.decorators import action
+from django.contrib.auth.models import User
+from rest_framework import status
+
+class ProfileViewSet(ViewSet):
+    @action(methods=['put'], detail=True)
+    def update_role(self, request, pk=None):
+        user = User.objects.get(pk=pk)
+        if user.is_staff:
+            user.is_staff = False
+        else:
+            user.is_staff = True
+        user.save()
+        return Response({}, status=status.HTTP_204_NO_CONTENT)

--- a/rareapi/views/Profiles.py
+++ b/rareapi/views/Profiles.py
@@ -21,7 +21,7 @@ class ProfileViewSet(ViewSet):
         try:
             rare_user = RareUsers.objects.get(pk=pk)
             user = User.objects.get(pk=rare_user.id)
-        except User.DoesNotExist:
+        except RareUsers.DoesNotExist:
             return Response({'message': 'user does not exit'}, status=status.HTTP_404_NOT_FOUND)
         if not request.auth.user.is_staff:
             return Response({'message':'only admins can change user roles'}, status=status.HTTP_403_FORBIDDEN)

--- a/rareapi/views/Profiles.py
+++ b/rareapi/views/Profiles.py
@@ -6,7 +6,7 @@ from rest_framework import status
 from django.core.exceptions import ValidationError
 
 class ProfileViewSet(ViewSet):
-    @action(methods=['put'], detail=True)
+    @action(methods=['patch'], detail=True)
     def update_role(self, request, pk=None):
         try:
             user = User.objects.get(pk=pk)
@@ -24,17 +24,3 @@ class ProfileViewSet(ViewSet):
             return Response({"reason": ex.message}, status=status.HTTP_400_BAD_REQUEST)
         return Response({}, status=status.HTTP_204_NO_CONTENT)
 
-
-
-
-
-
-        # try:
-        #     user = User.objects.get(pk=pk)
-        #     if user.is_staff:
-        #         user.is_staff = False
-        #     else:
-        #         user.is_staff = True
-        #     user.save()
-        #     return Response({}, status=status.HTTP_204_NO_CONTENT)
-        # except 

--- a/rareapi/views/Profiles.py
+++ b/rareapi/views/Profiles.py
@@ -15,24 +15,26 @@ class ProfileViewSet(ViewSet):
         return Response(serializer.data)
 
 
-    """PLEASE DISREGARD THE COMMENTED IT IS NOT UP TO STANDARDS"""
-    # @action(methods=['patch'], detail=True)
-    # def update_role(self, request, pk=None):
-    #     try:
-    #         user = User.objects.get(pk=pk)
-    #     except User.DoesNotExist:
-    #         return Response({'message': 'user does not exit'}, status=status.HTTP_404_NOT_FOUND)
-    #     if not request.auth.user.is_staff:
-    #         return Response({'message':'only admins can change user roles'}, status=status.HTTP_403_FORBIDDEN)
-    #     if user.is_staff:
-    #         user.is_staff = False
-    #     else:
-    #         user.is_staff = True
-    #     try:
-    #         user.save()
-    #     except ValidationError as ex:
-    #         return Response({"reason": ex.message}, status=status.HTTP_400_BAD_REQUEST)
-    #     return Response({}, status=status.HTTP_204_NO_CONTENT)
+    """action to toggle between admin and author status depending on message from client"""
+    @action(methods=['patch'], detail=True)
+    def update_role(self, request, pk=None):
+        try:
+            rare_user = RareUsers.objects.get(pk=pk)
+            user = User.objects.get(pk=rare_user.id)
+        except User.DoesNotExist:
+            return Response({'message': 'user does not exit'}, status=status.HTTP_404_NOT_FOUND)
+        if not request.auth.user.is_staff:
+            return Response({'message':'only admins can change user roles'}, status=status.HTTP_403_FORBIDDEN)
+        if request.data["update_role"] == "author":
+            user.is_staff = False
+        else: 
+            if request.data["update_role"] == "admin":
+                user.is_staff = True
+        try:
+            user.save()
+        except ValidationError as ex:
+            return Response({"reason": ex.message}, status=status.HTTP_400_BAD_REQUEST)
+        return Response({}, status=status.HTTP_204_NO_CONTENT)
 
 class BasicProfileSerializer(serializers.ModelSerializer):
     class Meta:

--- a/rareapi/views/Profiles.py
+++ b/rareapi/views/Profiles.py
@@ -3,14 +3,38 @@ from rest_framework.viewsets import ViewSet
 from rest_framework.decorators import action
 from django.contrib.auth.models import User
 from rest_framework import status
+from django.core.exceptions import ValidationError
 
 class ProfileViewSet(ViewSet):
     @action(methods=['put'], detail=True)
     def update_role(self, request, pk=None):
-        user = User.objects.get(pk=pk)
+        try:
+            user = User.objects.get(pk=pk)
+        except User.DoesNotExist:
+            return Response({'message': 'user does not exit'}, status=status.HTTP_404_NOT_FOUND)
+        if not request.auth.user.is_staff:
+            return Response({'message':'only admins can change user roles'}, status=status.HTTP_403_FORBIDDEN)
         if user.is_staff:
             user.is_staff = False
         else:
             user.is_staff = True
-        user.save()
+        try:
+            user.save()
+        except ValidationError as ex:
+            return Response({"reason": ex.message}, status=status.HTTP_400_BAD_REQUEST)
         return Response({}, status=status.HTTP_204_NO_CONTENT)
+
+
+
+
+
+
+        # try:
+        #     user = User.objects.get(pk=pk)
+        #     if user.is_staff:
+        #         user.is_staff = False
+        #     else:
+        #         user.is_staff = True
+        #     user.save()
+        #     return Response({}, status=status.HTTP_204_NO_CONTENT)
+        # except 

--- a/rareapi/views/Profiles.py
+++ b/rareapi/views/Profiles.py
@@ -1,26 +1,43 @@
+from django.http.response import HttpResponseServerError
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 from rest_framework.decorators import action
 from django.contrib.auth.models import User
+from rareapi.models import RareUsers
 from rest_framework import status
 from django.core.exceptions import ValidationError
+from rest_framework import serializers
 
 class ProfileViewSet(ViewSet):
-    @action(methods=['patch'], detail=True)
-    def update_role(self, request, pk=None):
-        try:
-            user = User.objects.get(pk=pk)
-        except User.DoesNotExist:
-            return Response({'message': 'user does not exit'}, status=status.HTTP_404_NOT_FOUND)
-        if not request.auth.user.is_staff:
-            return Response({'message':'only admins can change user roles'}, status=status.HTTP_403_FORBIDDEN)
-        if user.is_staff:
-            user.is_staff = False
-        else:
-            user.is_staff = True
-        try:
-            user.save()
-        except ValidationError as ex:
-            return Response({"reason": ex.message}, status=status.HTTP_400_BAD_REQUEST)
-        return Response({}, status=status.HTTP_204_NO_CONTENT)
+    def list(self, request):
+        users = RareUsers.objects.all()
+        serializer = BasicProfileSerializer(users, many=True, context={'request':request})
+        return Response(serializer.data)
+
+
+    """PLEASE DISREGARD THE COMMENTED IT IS NOT UP TO STANDARDS"""
+    # @action(methods=['patch'], detail=True)
+    # def update_role(self, request, pk=None):
+    #     try:
+    #         user = User.objects.get(pk=pk)
+    #     except User.DoesNotExist:
+    #         return Response({'message': 'user does not exit'}, status=status.HTTP_404_NOT_FOUND)
+    #     if not request.auth.user.is_staff:
+    #         return Response({'message':'only admins can change user roles'}, status=status.HTTP_403_FORBIDDEN)
+    #     if user.is_staff:
+    #         user.is_staff = False
+    #     else:
+    #         user.is_staff = True
+    #     try:
+    #         user.save()
+    #     except ValidationError as ex:
+    #         return Response({"reason": ex.message}, status=status.HTTP_400_BAD_REQUEST)
+    #     return Response({}, status=status.HTTP_204_NO_CONTENT)
+
+class BasicProfileSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = RareUsers
+        fields = ('id', 'username', 'is_staff', 'active')
+    
+
 

--- a/rareapi/views/Profiles.py
+++ b/rareapi/views/Profiles.py
@@ -24,10 +24,10 @@ class ProfileViewSet(ViewSet):
             return Response({'message': 'user does not exit'}, status=status.HTTP_404_NOT_FOUND)
         if not request.auth.user.is_staff:
             return Response({'message':'only admins can change user roles'}, status=status.HTTP_403_FORBIDDEN)
-        if request.data["update_role"] == "author":
+        if request.data["is_staff"] == "false":
             user.is_staff = False
         else: 
-            if request.data["update_role"] == "admin":
+            if request.data["is_staff"] == "true":
                 user.is_staff = True
         try:
             user.save()

--- a/rareapi/views/__init__.py
+++ b/rareapi/views/__init__.py
@@ -5,3 +5,4 @@ from .Posts import PostViewSet
 from .Tags import TagViewSet
 from .Comments import CommentViewSet
 from .PostTags import PostTagsViewSet
+from .Profiles import ProfileViewSet


### PR DESCRIPTION
# Description
toggle the is_staff value of a django user via PATCH request to action in ProfileViewSet; list basic profile info for a ProfileList view on client side
## Type of change
- [ ] New feature (non-breaking change which adds functionality)
# How Has This Been Tested?
Please describe step-by-step the process that a reviewer can follow to adequately test this PR. 
- [ ] in postman, go to the headers tab and copy `Token 7f6d2aca4d0d1e7f4e606c36b592f7736000ee92` into the Authorization Key's Value field (this will make you an admin as long as you have run the most recent main's fixtures)
- [ ] run a GET in postman to /profiles and verify that user w id of 1 has status of is_staff : false
- [ ] run a PATCH to `http://localhost:8000/profiles/1/update_role` with an object in the request body of {"is_staff": "true"}, verify you get a 204 no content message back with an empty object
- [ ] re-run the GET and check that is_staff for that user id is now True
- [ ] repeat PATCH action but change the value in the body to "false"; run the GET again and make sure it changed back
- [ ] put in a bogus user id number instead of 1 and try to run the PATCH again, make sure you get a 404/matching response back
# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings