### PR TITLE
Je restrict tags and categories

### DIFF
--- a/rareapi/views/Tags.py
+++ b/rareapi/views/Tags.py
@@ -13,6 +13,12 @@ class TagViewSet(ViewSet):
         return Response(serializer.data)
 
     def create(self, request):
+        if not request.auth.user.is_staff:
+            return Response(
+                {'message': 'You must be an admin to create tags.'},
+                status=status.HTTP_403_FORBIDDEN
+            )
+
         tag = Tags()
         tag.label = request.data["label"]
         

--- a/rareapi/views/Tags.py
+++ b/rareapi/views/Tags.py
@@ -30,6 +30,12 @@ class TagViewSet(ViewSet):
             return Response({"reason": ex.message}, status=status.HTTP_400_BAD_REQUEST)
 
     def update(self, request, pk=None):
+        if not request.auth.user.is_staff:
+            return Response(
+                {'message': 'You must be an admin to update tags.'},
+                status=status.HTTP_403_FORBIDDEN
+            )
+
         try:
             tag = Tags.objects.get(pk=pk)
         except Tags.DoesNotExist:

--- a/rareapi/views/Tags.py
+++ b/rareapi/views/Tags.py
@@ -45,6 +45,12 @@ class TagViewSet(ViewSet):
         return Response({}, status=status.HTTP_204_NO_CONTENT)
 
     def destroy(self, request, pk=None):
+        if not request.auth.user.is_staff:
+            return Response(
+                {'message': 'You must be an admin to delete tags.'},
+                status=status.HTTP_403_FORBIDDEN
+            )
+
         try:
             tag = Tags.objects.get(pk=pk)
             tag.delete()

--- a/rareapi/views/category.py
+++ b/rareapi/views/category.py
@@ -12,6 +12,13 @@ class CategoryViewSet(ViewSet):
         """POST a new Categories object"""
 
         # VALIDATION:
+        # Ensure that the user is an admin
+        if not request.auth.user.is_staff:
+            return Response(
+                {'message': 'You must be an admin to create categories.'},
+                status=status.HTTP_403_FORBIDDEN
+            )
+
         # Ensure that client request included the required `label` key in POST body
         try:
             label = request.data['label']

--- a/rareapi/views/category.py
+++ b/rareapi/views/category.py
@@ -99,6 +99,12 @@ class CategoryViewSet(ViewSet):
         Returns:
             Response -- Empty body with 204 status code
         """
+        if not request.auth.user.is_staff:
+            return Response(
+                {'message': 'You must be an admin to update categories.'},
+                status=status.HTTP_403_FORBIDDEN
+            )
+
         # Do mostly the same thing as POST, but instead of
         # creating a new instance of Category, get the Category record
         # from the database whose primary key is `pk`

--- a/rareapi/views/category.py
+++ b/rareapi/views/category.py
@@ -56,6 +56,12 @@ class CategoryViewSet(ViewSet):
     def destroy(self, request, pk=None):
         """DELETE a category with the given pk"""
 
+        if not request.auth.user.is_staff:
+            return Response(
+                {'message': 'You must be an admin to delete categories.'},
+                status=status.HTTP_403_FORBIDDEN
+            )
+
         try:
             category = Categories.objects.get(pk=pk)
 

--- a/rareapi/views/category.py
+++ b/rareapi/views/category.py
@@ -1,8 +1,8 @@
 """Category ViewSet and Serializers"""
-from rest_framework.status import HTTP_204_NO_CONTENT
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
 from rest_framework import status, serializers
+from django.http.response import HttpResponseServerError
 from rareapi.models import Categories
 
 class CategoryViewSet(ViewSet):
@@ -65,7 +65,7 @@ class CategoryViewSet(ViewSet):
             )
 
         category.delete()
-        return Response({}, HTTP_204_NO_CONTENT)
+        return Response({}, status=status.HTTP_204_NO_CONTENT)
     
     
     def retrieve(self, request, pk=None):


### PR DESCRIPTION
# Description
This PR adds validation checks in the Tag and Category ViewSets. Now only admin users can create / update / delete tags and categories.

Fixes #262 #268

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Please describe step-by-step the process that a reviewer can follow to adequately test this PR. 
- [ ] In Postman, try to POST, UPDATE, and DELETE for a category as an admin and verify that you can do all of these things. Then try to do it as a non-admin and verify you get HTTP 403 responses and descriptive error messages for each operation.
- [ ] In Postman, try to POST, UPDATE, and DELETE for a tag as an admin and verify that you can do all of these things. Then try to do it as a non-admin and verify you get HTTP 403 responses and descriptive error messages for each operation.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings