### PR TITLE
Je restrict comments

### DIFF
--- a/rareapi/views/Comments.py
+++ b/rareapi/views/Comments.py
@@ -86,12 +86,22 @@ class CommentViewSet(ViewSet):
     def destroy(self, request, pk=None):
         try:
             comment = Comments.objects.get(pk=pk)
-            comment.delete()
-            return Response({}, status=status.HTTP_204_NO_CONTENT)
         except Comments.DoesNotExist as ex:
             return Response({'message': ex.args[0]})
+
+        rare_user = RareUsers.objects.get(user=request.auth.user)
+        if (comment.author != rare_user) and (not request.auth.user.is_staff):
+            return Response(
+                {'message': 'Comments can only be deleted by admins or the users who authored them.'},
+                status=status.HTTP_403_FORBIDDEN
+            )
+        
+        try:
+            comment.delete()
         except Exception as ex:
             return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+        return Response({}, status=status.HTTP_204_NO_CONTENT)
 
 
 

--- a/rareapi/views/Comments.py
+++ b/rareapi/views/Comments.py
@@ -1,7 +1,5 @@
-
 from rareapi.models import Comments,Posts,RareUsers
 from django.core.exceptions import ValidationError
-from django.http import HttpResponseServerError
 from rest_framework import status
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
@@ -11,14 +9,10 @@ from django.utils import timezone
 
 class RareUsersSerializer(serializers.ModelSerializer):
     """JSON serializer for rareUsers"""
-   
-
 
     class Meta:
         model = RareUsers
         fields = ['id', 'username']
-
-   
 
 class CommentSerializer(serializers.ModelSerializer):
     """JSON serializer for comment creator"""
@@ -27,8 +21,6 @@ class CommentSerializer(serializers.ModelSerializer):
     class Meta:
         model = Comments
         fields = ('id','author', 'content', 'subject', 'created_on')
-
-
 
 class CommentViewSet(ViewSet):
 
@@ -75,6 +67,14 @@ class CommentViewSet(ViewSet):
             comment = Comments.objects.get(pk=pk)
         except Comments.DoesNotExist as ex:
             return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+
+        rare_user = RareUsers.objects.get(user=request.auth.user)
+        if not comment.author == rare_user:
+            return Response(
+                {'message': 'Comments cannot be updated by users who did not author them.'},
+                status=status.HTTP_403_FORBIDDEN
+            )
+
         comment.content = request.data["content"]
         comment.subject = request.data["subject"]
         try:

--- a/rareapi/views/Comments.py
+++ b/rareapi/views/Comments.py
@@ -69,7 +69,7 @@ class CommentViewSet(ViewSet):
             return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
 
         rare_user = RareUsers.objects.get(user=request.auth.user)
-        if not comment.author == rare_user:
+        if comment.author != rare_user:
             return Response(
                 {'message': 'Comments cannot be updated by users who did not author them.'},
                 status=status.HTTP_403_FORBIDDEN


### PR DESCRIPTION
# Description
This PR adds permission checks to the Comments ViewSet. Specifically:

- Authors can edit/delete any of their own comments
- Admins can edit their own comments, and delete *any* comment

Fixes #267 

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Please describe step-by-step the process that a reviewer can follow to adequately test this PR. 
- [ ] In Postman, send a PUT to a comment using an auth header of the user who authored that comment and verify your edit to the comment is successful.
- [ ] In Postman, send a DELETE to a comment using an auth header of the user who authored that comment and verify your delete is successful.
- [ ] In Postman, send a DELETE to any comment using an admin auth header and verify your delete is successful.
- [ ] In Postman, send a PUT to a comment that you did not author and verify that you get an HTTP 403 error. Verify that this is true whether you are using an admin auth header or not.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings