### PR TITLE
Mt unsub

### DIFF
--- a/news_hounds_django_server/urls.py
+++ b/news_hounds_django_server/urls.py
@@ -1,8 +1,7 @@
-from rareapi.views.Subscriptions import SubscriptionsViewSet
 from django.conf.urls import include
 from django.urls import path
 from rest_framework import routers
-from rareapi.views import register_user, login_user, PostViewSet, TagViewSet, CategoryViewSet, CommentViewSet, PostTagsViewSet, ProfileViewSet
+from rareapi.views import register_user, login_user, PostViewSet, TagViewSet, CategoryViewSet, CommentViewSet, PostTagsViewSet, ProfileViewSet, SubscriptionsViewSet
 from django.conf.urls.static import static
 from django.conf import settings
 

--- a/rareapi/views/Subscriptions.py
+++ b/rareapi/views/Subscriptions.py
@@ -42,14 +42,14 @@ class SubscriptionsViewSet(ViewSet):
     def end_subscription(self,request):
         #First gather all the data needed from the request
         author_id = request.data["author_id"]
-        #this is the author
+        #This is the author
         author = RareUsers.objects.get(pk=author_id)
         djangoUser = request.auth.user
-        #this is the follower (the person logged in and Unsubscribing)
+        #This is the follower (the person logged in and Unsubscribing)
         follower = RareUsers.objects.get(user=djangoUser)
-        #next get the subscriptions
+        #Next get the subscriptions
         subscription=Subscriptions.objects.get(author=author, follower=follower,ended_on=None)
-        
+        #Finally add the ended on time at the time of request
         subscription.ended_on = timezone.now()
         try:
             subscription.save()

--- a/rareapi/views/Subscriptions.py
+++ b/rareapi/views/Subscriptions.py
@@ -53,7 +53,7 @@ class SubscriptionsViewSet(ViewSet):
         subscription.ended_on = timezone.now()
         try:
             subscription.save()
-            return Response({}, status=status.HTTP_201_CREATED)
+            return Response({}, status=status.HTTP_204_NO_CONTENT)
         except Exception as ex:
             return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
     

--- a/rareapi/views/Subscriptions.py
+++ b/rareapi/views/Subscriptions.py
@@ -1,6 +1,7 @@
 """ View Module FOr handling requests about subscriptions"""
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
+from rest_framework.decorators import action
 from rest_framework import status
 from django.utils import timezone
 from rareapi.models import RareUsers, Subscriptions
@@ -36,22 +37,64 @@ class SubscriptionsViewSet(ViewSet):
             return Response({}, status=status.HTTP_201_CREATED)
         except Exception as ex:
             return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
-    
-    def partial_update(self, request, pk=None):
-        """Handle PATCH request"""
-            # author_id = request.data["author_id"]
-            # djangoUser = request.auth.user
-            # follower = RareUsers.objects.get(user=djangoUser)
-# Get the subscription based off it's primary key
-        try:
-            subscription = Subscriptions.objects.get(follower=follower, author=author, ended_on=None)
-        except Subscriptions.DoesNotExist:
-            return Response({'message': 'There is no Subscription with this given ID'}, status=status.HTTP_400_BAD_REQUEST)
-# Next update the request with the updated 
+    """action to update the ended_on date for when someone unsubscribes"""
+    @action(methods=['put'], detail=False)
+    def update_subscription(self,request):
+        #First gather all the data needed from the request
+        author_id = request.data["author_id"]
+        #this is the author
+        author = RareUsers.objects.get(pk=author_id)
+        djangoUser = request.auth.user
+        #this is the follower (the person logged in and Unsubscribing)
+        follower = RareUsers.objects.get(user=djangoUser)
+        #next get the subscriptions
+        subscription=Subscriptions.objects.get(author=author, follower=follower,ended_on=None)
+        
         subscription.ended_on = timezone.now()
-
-        try: 
+        try:
             subscription.save()
-            return Response({}, status=status.HTTP_204_NO_CONTENT)
+            return Response({}, status=status.HTTP_201_CREATED)
         except Exception as ex:
             return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#     def partial_update(self, request, pk=None):
+#         """Handle PATCH request"""
+#             # author_id = request.data["author_id"]
+#             # djangoUser = request.auth.user
+#             # follower = RareUsers.objects.get(user=djangoUser)
+# # Get the subscription based off it's primary key
+#         try:
+#             subscription = Subscriptions.objects.get(follower=follower, author=author, ended_on=None)
+#         except Subscriptions.DoesNotExist:
+#             return Response({'message': 'There is no Subscription with this given ID'}, status=status.HTTP_400_BAD_REQUEST)
+# Next update the request with the updated 
+#         subscription.ended_on = timezone.now()
+
+#         try: 
+#             subscription.save()
+#             return Response({}, status=status.HTTP_204_NO_CONTENT)
+#         except Exception as ex:
+#             return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/rareapi/views/Subscriptions.py
+++ b/rareapi/views/Subscriptions.py
@@ -39,7 +39,7 @@ class SubscriptionsViewSet(ViewSet):
             return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
     """action to update the ended_on date for when someone unsubscribes"""
     @action(methods=['put'], detail=False)
-    def update_subscription(self,request):
+    def end_subscription(self,request):
         #First gather all the data needed from the request
         author_id = request.data["author_id"]
         #this is the author
@@ -59,42 +59,3 @@ class SubscriptionsViewSet(ViewSet):
     
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-#     def partial_update(self, request, pk=None):
-#         """Handle PATCH request"""
-#             # author_id = request.data["author_id"]
-#             # djangoUser = request.auth.user
-#             # follower = RareUsers.objects.get(user=djangoUser)
-# # Get the subscription based off it's primary key
-#         try:
-#             subscription = Subscriptions.objects.get(follower=follower, author=author, ended_on=None)
-#         except Subscriptions.DoesNotExist:
-#             return Response({'message': 'There is no Subscription with this given ID'}, status=status.HTTP_400_BAD_REQUEST)
-# Next update the request with the updated 
-#         subscription.ended_on = timezone.now()
-
-#         try: 
-#             subscription.save()
-#             return Response({}, status=status.HTTP_204_NO_CONTENT)
-#         except Exception as ex:
-#             return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/rareapi/views/Subscriptions.py
+++ b/rareapi/views/Subscriptions.py
@@ -36,3 +36,22 @@ class SubscriptionsViewSet(ViewSet):
             return Response({}, status=status.HTTP_201_CREATED)
         except Exception as ex:
             return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+    
+    def partial_update(self, request, pk=None):
+        """Handle PATCH request"""
+            # author_id = request.data["author_id"]
+            # djangoUser = request.auth.user
+            # follower = RareUsers.objects.get(user=djangoUser)
+# Get the subscription based off it's primary key
+        try:
+            subscription = Subscriptions.objects.get(follower=follower, author=author, ended_on=None)
+        except Subscriptions.DoesNotExist:
+            return Response({'message': 'There is no Subscription with this given ID'}, status=status.HTTP_400_BAD_REQUEST)
+# Next update the request with the updated 
+        subscription.ended_on = timezone.now()
+
+        try: 
+            subscription.save()
+            return Response({}, status=status.HTTP_204_NO_CONTENT)
+        except Exception as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
# Description
Added a custom action to update the subscriptions object to change the ended_on datetime to the time of request.
## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)
# How Has This Been Tested?
NOTE: you do not need to follow these directions exactly, these are for a newly seeded database.  If you have some subscriptions just send the author_id in the request and it should work.
- [ ]  `git fetch --all`
- [ ] `git checkout mt-unsub`
- [ ] make sure your server is running
- [ ] assuming you have a fresh database running the `sh seed.sh` you can add this token `fa2eba9be8282d595c997ee5cd49f2ed31f65bed` to postman which is user 1
- [ ] user 1 has subscribed to one user being user 3 so put `{ "author_id": 3 }` in the request body
- [ ] send a PUT with the url of `http://localhost:8000/subscriptions/end_subscription` and the mentioned request body and get a 201 response
- [ ] check your data base in VS to see a newly added ended on date.
# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings