### PR TITLE
Gs server reactions

### DIFF
--- a/news_hounds_django_server/urls.py
+++ b/news_hounds_django_server/urls.py
@@ -2,7 +2,7 @@ from rareapi.views.Subscriptions import SubscriptionsViewSet
 from django.conf.urls import include
 from django.urls import path
 from rest_framework import routers
-from rareapi.views import register_user, login_user, PostViewSet, TagViewSet, CategoryViewSet, CommentViewSet, PostTagsViewSet, ProfileViewSet
+from rareapi.views import register_user, login_user, PostViewSet, TagViewSet, CategoryViewSet, CommentViewSet, PostTagsViewSet, ProfileViewSet, ReactionsViewSet
 from django.conf.urls.static import static
 from django.conf import settings
 
@@ -16,6 +16,7 @@ router.register(r'posttags', PostTagsViewSet, 'posttags' )
 router.register(r'categories', CategoryViewSet, 'category')
 router.register(r'subscriptions', SubscriptionsViewSet, 'subscription')
 router.register(r'profiles', ProfileViewSet, 'profile')
+router.register(r'reactions', ReactionsViewSet, 'reaction')
 
 urlpatterns = [
     path('', include(router.urls)),

--- a/rareapi/fixtures/reactions.json
+++ b/rareapi/fixtures/reactions.json
@@ -4,7 +4,7 @@
         "pk": 1,
         "fields": {
             "label": "Love",
-            "image_url": "/media/reactions/Love.png"
+            "image_url": "reactions/Love.png"
         }
     },
     {
@@ -12,7 +12,7 @@
         "pk": 2,
         "fields": {
             "label": "Mindblown",
-            "image_url": "/media/reactions/Mindblown.png"
+            "image_url": "reactions/Mindblown.png"
         }
     },
     {
@@ -20,7 +20,7 @@
         "pk": 3,
         "fields": {
             "label": "Interesting",
-            "image_url": "/media/reactions/Interesting.png"
+            "image_url": "reactions/Interesting.png"
         }
     },
     {
@@ -28,15 +28,15 @@
         "pk": 4,
         "fields": {
             "label": "Nuclear",
-            "image_url": "/media/reactions/Nuclear.png"
+            "image_url": "reactions/Nuclear.png"
         }
     },
     {
         "model": "rareapi.reactions",
-        "pk": 4,
+        "pk": 5,
         "fields": {
             "label": "GoodBoy",
-            "image_url": "/media/reactions/GoodBoy.png"
+            "image_url": "reactions/GoodBoy.png"
         }
     }
 ]

--- a/rareapi/models/Posts.py
+++ b/rareapi/models/Posts.py
@@ -35,7 +35,7 @@ class Posts(models.Model):
         per-post count in key:val pairs
         """
         post_reactions = self.postreactions_set.all()
-        return post_reactions.values('reaction__label', 'reaction__image_url').annotate(count=Count('reaction__id'))
+        return post_reactions.values('reaction__label', 'reaction__id').annotate(count=Count('reaction__id'))
 
 
 

--- a/rareapi/views/Posts.py
+++ b/rareapi/views/Posts.py
@@ -6,12 +6,14 @@ from rest_framework.viewsets import ViewSet
 from rest_framework import serializers
 from rest_framework.response import Response
 from rest_framework import status
-from rareapi.models import Posts, RareUsers, Categories
+from rareapi.models import Posts, RareUsers, Categories, Reactions
 from datetime import date
 from django.core.exceptions import ValidationError
 
+
 class PostViewSet(ViewSet):
     """Rare Posts"""
+
     def create(self, request):
         """Handle POST operations
 
@@ -22,35 +24,35 @@ class PostViewSet(ViewSet):
         post = Posts()
         post.user = rare_user
 
-        #Try to assign the category to the post, but respond with an error if the category doesn't exist
-        try: 
+        # Try to assign the category to the post, but respond with an error if the category doesn't exist
+        try:
             category = Categories.objects.get(pk=request.data["category_id"])
             post.category = category
         except Categories.DoesNotExist as ex:
             return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
-    
+
         post.title = request.data["title"]
 
-        #Assign the publication date to be the current date
+        # Assign the publication date to be the current date
         post.publication_date = date.today()
 
         post.image_url = request.data["image_url"]
         post.content = request.data["content"]
-        
-        #See if author is admin; if so, assign approved to True, else False
+
+        # See if author is admin; if so, assign approved to True, else False
         if request.auth.user.is_staff:
             post.approved = True
         else:
             post.approved = False
 
-        #extract tag ids from request and try to convert that collection to a queryset of actual tags
+        # extract tag ids from request and try to convert that collection to a queryset of actual tags
         tag_ids = request.data["tagIds"]
 
         try:
             tags = [Tags.objects.get(pk=tag_id) for tag_id in tag_ids]
         except Tags.DoesNotExist:
             return Response({'message': 'request contains a tagId for a non-existent tag'}, status=status.HTTP_422_UNPROCESSABLE_ENTITY)
-        
+
         # # Try to save the new post to the database, then
         # # serialize the post instance as JSON, and send the
         # # JSON as a response to the client request
@@ -62,7 +64,7 @@ class PostViewSet(ViewSet):
         except ValidationError as ex:
             return Response({"reason": ex.message}, status=status.HTTP_400_BAD_REQUEST)
 
-        #for each tag
+        # for each tag
         for tag in tags:
             post_tag = PostTags(post=post, tag=tag)
             post_tag.save()
@@ -70,44 +72,44 @@ class PostViewSet(ViewSet):
         serializer = PostSerializer(post, context={'request': request})
         return Response(serializer.data)
 
-
     def update(self, request, pk=None):
         """ Handle an update request for a post
 
         'user', 'publication_date' and 'approved' attributes are not subject to change on update as currently configured 
         """
 
-        ##Find the post being updated based on it's primary key  
+        # Find the post being updated based on it's primary key
         post = Posts.objects.get(pk=pk)
 
-        #try to find the category that matches the one referenced in the request and save it as the post's 'category' value
-        try: 
+        # try to find the category that matches the one referenced in the request and save it as the post's 'category' value
+        try:
             category = Categories.objects.get(pk=request.data["category_id"])
             post.category = category
         except Categories.DoesNotExist as ex:
             return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
 
-        #save basic (non-associated) properties
+        # save basic (non-associated) properties
         post.title = request.data["title"]
         post.image_url = request.data["image_url"]
         post.content = request.data["content"]
 
-        #extract tag ids from request and try to convert that collection to a queryset of actual tags
+        # extract tag ids from request and try to convert that collection to a queryset of actual tags
         request_tag_ids = request.data["tagIds"]
         try:
-            request_tags = [ Tags.objects.get(pk=tag_id) for tag_id in request_tag_ids ]
+            request_tags = [Tags.objects.get(pk=tag_id)
+                            for tag_id in request_tag_ids]
         except Tags.DoesNotExist:
             return Response({'message': 'request contains a tagId for a non-existent tag'}, status=status.HTTP_422_UNPROCESSABLE_ENTITY)
 
-        #save post object
+        # save post object
         post.save()
 
-        #look through all of the posttags in the DB, and assign those for which the post being updated is the 'post' attribute value to a new collection
+        # look through all of the posttags in the DB, and assign those for which the post being updated is the 'post' attribute value to a new collection
         # (in other words, the current, pre-update collection of this post's associated 'posttags')
         current_posttags = PostTags.objects.filter(post=post)
 
-        #create new queryset from the collection above that is ONLY those posttags for which the 'tag' attribute value doesn't match 
-        #any of the tags specified in the request. Then delete them all. 
+        # create new queryset from the collection above that is ONLY those posttags for which the 'tag' attribute value doesn't match
+        # any of the tags specified in the request. Then delete them all.
         current_posttags.exclude(tag__in=request_tags).delete()
 
         # for each tag in the set of 'tags' from the request, try to find an existing entry in the current_posttags that
@@ -116,7 +118,7 @@ class PostViewSet(ViewSet):
             try:
                 current_posttags.get(tag=tag)
             except PostTags.DoesNotExist:
-                new_posttag = PostTags(post=post,tag=tag)
+                new_posttag = PostTags(post=post, tag=tag)
                 new_posttag.save()
 
         return Response({}, status=status.HTTP_204_NO_CONTENT)
@@ -143,14 +145,14 @@ class PostViewSet(ViewSet):
                 )
 
             post.approved = request.data['approved']
-        
+
         # Save whatever has been updated in the PATCH request
         try:
             post.save()
         except ValidationError as ex:
             return Response({"reason": ex.message}, status=status.HTTP_400_BAD_REQUEST)
 
-        return Response({}, status=status.HTTP_204_NO_CONTENT)       
+        return Response({}, status=status.HTTP_204_NO_CONTENT)
 
     def list(self, request):
         """Handle GET requests to posts resource
@@ -178,19 +180,30 @@ class PostViewSet(ViewSet):
             # filter down posts to only those whose author is in the list of authors the current
             # user is actively following
             posts = posts.filter(user__in=current_rare_user.authors_following)
-        
-        serializer = PostSerializer(posts, many=True, context={'request': request})
+
+        serializer = PostSerializer(
+            posts, many=True, context={'request': request})
         return Response(serializer.data)
-    
+
     def retrieve(self, request, pk=None):
         """Handle GET request for single post
         Returns:
-            Response JSON serielized post instance
+            Response JSON serialized post instance
         """
         try:
+            request_user = RareUsers.objects.get(user=request.auth.user)
             post = Posts.objects.get(pk=pk)
+
+        ## in the response body, embed a list of the Ids of all the <Reactions>
+        ## for which its true that a <PostReaction> exists in which the 
+        ## <User> is this request_user and the <Post> is this post
+
+            user_reactions = post.postreactions_set.filter(user=request_user).values_list('reaction__id', flat=True)
+
             serializer = PostSerializer(post, context={'request': request})
-            return Response(serializer.data)
+            post_data = serializer.data
+            post_data["user_reactions"] = user_reactions
+            return Response(post_data)
         except Exception as ex:
             return HttpResponseServerError(ex)
 
@@ -204,26 +217,27 @@ class PostViewSet(ViewSet):
         except Exception as ex:
             return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
-    
-    
 
 class PostRareUserSerializer(serializers.ModelSerializer):
-    """Serializer for RareUser Info in a post"""         
+    """Serializer for RareUser Info in a post"""
     class Meta:
         model = RareUsers
         fields = ('id', 'bio', 'fullname', 'username')
+
 
 class PostTagSerializer(serializers.ModelSerializer):
     class Meta:
         model = Tags
         fields = ('id', 'label')
 
+
 class PostSerializer(serializers.ModelSerializer):
     """Basic Serializer for single post"""
     user = PostRareUserSerializer(many=False)
     tags = PostTagSerializer(many=True)
+
     class Meta:
         model = Posts
-        fields = ('id', 'title', 'publication_date', 'content', 'user', 'category', 'image_url', 'approved', 'tags', 'reactions')
+        fields = ('id', 'title', 'publication_date', 'content', 'user',
+                  'category', 'image_url', 'approved', 'tags', 'reactions')
         depth = 1
-

--- a/rareapi/views/Reactions.py
+++ b/rareapi/views/Reactions.py
@@ -14,7 +14,8 @@ class ReactionsViewSet(ViewSet):
         except Exception as ex:
             return Response({'message' : ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
+
 class ReactionSerializer(serializers.ModelSerializer):
     class Meta:
         model = Reactions
-        fields = '__all__'
+        fields = ('label', 'image_url', 'id')

--- a/rareapi/views/Reactions.py
+++ b/rareapi/views/Reactions.py
@@ -1,0 +1,20 @@
+from rareapi.models import Reactions
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import status, serializers
+
+
+class ReactionsViewSet(ViewSet):
+    """Rare Reactions"""
+    def list(self, request):
+        reactions = Reactions.objects.all()
+        serializer = ReactionSerializer(reactions, many=True, context={'request': request})
+        try:
+            return Response(serializer.data, status=status.HTTP_200_OK)
+        except Exception as ex:
+            return Response({'message' : ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+class ReactionSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Reactions
+        fields = '__all__'

--- a/rareapi/views/__init__.py
+++ b/rareapi/views/__init__.py
@@ -7,3 +7,5 @@ from .Comments import CommentViewSet
 from .PostTags import PostTagsViewSet
 from .Subscriptions import SubscriptionsViewSet
 from .Profiles import ProfileViewSet
+from .Reactions import ReactionsViewSet
+


### PR DESCRIPTION
-removed relative path to img urls from “reactions” embedded on a post
-added separate viewset for reactions
-added property in post “retrieve” method to include list of all reaction Ids for current user
## Type of change
- [X] New feature (non-breaking change which adds functionality)
# How Has This Been Tested?
Please describe step-by-step the process that a reviewer can follow to adequately test this PR. 
- [x] In postman run a GET to /reactions, make sure you get a list of reactions back with label, image_url as an absolute path, and id
- [x] In postman run a GET to `/posts/<soomePostIdThatExists>` and make sure you see an array called user_reactions that contains Ids of reactions the user making the request has added to this post (if you run the magikal seed script, if you request posts/1 as user me@me.me aka `Token fa2eba9be8282d595c997ee5cd49f2ed31f65bed` you should see [1, 2, 3, 4]
- [x] for bonus points you can run a DELTE to /posts/1/reaction with {“reaction_id”: 1} in the body, then re-GET the post and make sure 1 is missing from that array OR you could just, ya know. wait to test this from the client PR coming upppp sooon
# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings